### PR TITLE
Fix typo in student assistant contract docs

### DIFF
--- a/docs/10-lab/10_processes/10.31.contracts_sa.md
+++ b/docs/10-lab/10_processes/10.31.contracts_sa.md
@@ -26,7 +26,7 @@ Jedem Ausnahmefall ist eine formlose Begründung zuzufügen, die vom direkten Vo
 ## Student assistants: After completing the Bachelor/Master
 
 Wenn ein Vertrag für eine SHK-Stelle mit abgeschlossenem Studium beantragen werden soll, das Abschlusszeugnis jedoch noch nicht vorliegt, besteht die Möglichkeit, den Vertrag trotzdem als „SHK mit Abschluss“ anzufragen.
-Denn man kann beim Prüfungsamt eine Bestätigung über den bestandenen Studienabschluss beantragen, diese wird dann ausgestellt und zugeschickt oder kann auch im Prüfungsamt abgeholte werden. Diese Bestätigung ersetzt vorübergehend das Abschlusszeugnis und dient dem Personalamt als Nachweis für die Vertragserstellung.
+Denn man kann beim Prüfungsamt eine Bestätigung über den bestandenen Studienabschluss beantragen, diese wird dann ausgestellt und zugeschickt oder kann auch im Prüfungsamt abgeholt werden. Diese Bestätigung ersetzt vorübergehend das Abschlusszeugnis und dient dem Personalamt als Nachweis für die Vertragserstellung.
 Sobald das offizielle Abschlusszeugnis erstellt wurde, muss dieses lediglich von der SHK per E-Mail an das Personalamt mit dem Sekretariat im CC nachgereicht werden.
 
 Send to **Referat III/2 (SHK Dienstvertrag/vertraulich)** via internal mail.


### PR DESCRIPTION
## Summary
- fix typo `abgeholte` -> `abgeholt`

## Testing
- `pre-commit` *(fails: `command not found`)*
- `npx markdownlint-cli docs/10-lab/10_processes/10.31.contracts_sa.md` *(fails: network access restricted)*

------
https://chatgpt.com/codex/tasks/task_e_686cd9871a5c832aa1c4d1a3fce0a337